### PR TITLE
Fix using puppeteer with output files

### DIFF
--- a/browser/puppeteer.js
+++ b/browser/puppeteer.js
@@ -9,13 +9,6 @@
  */
 const util = require('util');
 
-// map of puppeteer console types to their node counterpart
-const consoleMap = {
-  'warning' : 'warn',
-  'startGroup' : 'group',
-  'endGroup' : 'groupEnd',
-};
-
 export default function startPuppeteer({
   stdout,
   stderr,
@@ -43,20 +36,25 @@ export default function startPuppeteer({
       console.warn('The page has crashed.', err);
     });
 
+    let consolePromise = Promise.resolve();
+
     // console message args come in as handles, use this to evaluate them all
-    page.on('console', async msg => {
+    page.on('console', msg => {
       let msgType = msg._type;
 
-      // unknown console types are mapped or become a warning with addl context
-      if(consoleMap[msgType]) {
-        msgType = consoleMap[msgType];
-      }
-      else if(typeof console[msgType] === "undefined") {
-        msgType = 'warn';
-        console.warn(`UNKNOWN CONSOLE TYPE: ${msgType}`);
-      }
+      consolePromise = consolePromise.then(async () => {
+        // this is racy but how else to do it?
+        const testsAreRunning = await page.evaluate('window.testsAreRunning');
+        const messages = await Promise.all(
+          msg.args().map((arg) => arg.jsonValue()),
+        );
 
-      console[msgType](...await Promise.all(msg.args().map(arg => arg.jsonValue())));
+        if (msgType === 'error' && !testsAreRunning) {
+          stderr(util.format(...messages));
+        } else {
+          stdout(util.format(...messages));
+        }
+      });
     });
 
     await page.goto(process.env.ROOT_URL);
@@ -64,6 +62,7 @@ export default function startPuppeteer({
     await page.waitFor(() => window.testsDone, { timeout: 0 });
     const testFailures = await page.evaluate('window.testFailures');
 
+    await consolePromise;
     await page.close();
     await browser.close();
 


### PR DESCRIPTION
When using the `CLIENT_MOCHA_OUTPUT` env var, the messages logged in the browser console must be passed to the `stderr` and `stdout` functions to be saved to the file. However, when  `stderr` and `stdout` logged the messages to the server's console they sometimes were not formatted properly so when using puppeteer (and some other browsers) they are no longer used.

This PR changes it back to how it used to use [stderr and stdout](https://github.com/meteortesting/meteor-browser-tests/blob/5fbcff0cf5c39f9da09e903f4e4ce4ef1cba03cc/browser/puppeteer.js) to fix storing the messages in a file, but it now passes the messages to [util.format](https://nodejs.org/api/util.html#util_util_format_format_args), which is what Node.js uses to format in many of the console functions.
