### PR TITLE
Fix: Allow client tests to complete if they take more than 30 seconds

### DIFF
--- a/browser/playwright_worker.mjs
+++ b/browser/playwright_worker.mjs
@@ -56,7 +56,7 @@ async function startPlaywright(done) {
 
   await page.goto(process.env.ROOT_URL);
 
-  await page.waitForFunction(() => window.testsDone, { timeout: 0 });
+  await page.waitForFunction(() => window.testsDone, [], { timeout: 0 });
   const testFailures = await page.evaluate('window.testFailures');
 
   await page.close();


### PR DESCRIPTION
In puppeteer, the options to `page.waitForFunction` are the second parameter, and all subsequent parameters are passed to the function. In playwright, the args are the second parameter, and the options are the third parameter. As such, the playwright driver wasn't overriding the default 30 second timeout on `page.waitForFunction`, causing the promise to reject, which meant the `done` callback was never called.
Fixes #47 