### PR TITLE
Adapt browser drivers to be compatible with latest 4.x selenium-websdriver version

### DIFF
--- a/browser/chromedriver.js
+++ b/browser/chromedriver.js
@@ -19,12 +19,6 @@ process.on('exit', () => {
   }
 });
 
-function countPlaceholders(inputString) {
-  const placeholderPattern = /%[sdifjoO]/g; // Regular expression to match %s, %d, and similar placeholders
-  const matches = inputString.match(placeholderPattern);
-  return matches ? matches.length : 0;
-}
-
 export default function startChrome({
   stdout,
   stderr,


### PR DESCRIPTION
As reported in this issue https://github.com/Meteor-Community-Packages/meteor-browser-tests/issues/36, browser drivers are not working anymore for latest selenium-webdriver versions.

In this PR I attempt to support them again to be up to date with latest selenium version 4.x.

I adapted the code to use the newer API from selenium and also tweaked the logs displaying since latest version introduce breaking on logs as they are sent to be formatted using placeholders (%s %d and so on).

- [x] Review chromedriver
- [x] Why colors are not showing? It may just be an issue with my env as I already experienced.


## Demo
![image](https://github.com/Meteor-Community-Packages/meteor-browser-tests/assets/2581993/7ff137a7-7039-4749-9663-6fc2aeeca9a5)

### Running sucessfully
![image](https://github.com/Meteor-Community-Packages/meteor-browser-tests/assets/2581993/c8221633-e633-42c9-a024-369fcab386ef)

### Running with errors
![image](https://github.com/Meteor-Community-Packages/meteor-browser-tests/assets/2581993/73e79f9e-553a-48f3-b863-6b9884008d8d)
