### PR TITLE
Support latest browser versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ When using your test driver package, you will need to install the necessary NPM 
 ### Puppeteer
 
 ```bash
-$ npm i --save-dev puppeteer@^1.5.0
+$ npm i --save-dev puppeteer@^19.11.1
 $ TEST_BROWSER_DRIVER=puppeteer meteor test --once --driver-package <your package name>
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,8 +61,20 @@ When using your test driver package, you will need to install the necessary NPM 
 
 ### Puppeteer
 
+`puppeteer@^19.11.1` is the latest version with Node 14 compatibility (Meteor 2.x is set to use Node.js version 14.x by default).
+
 ```bash
 $ npm i --save-dev puppeteer@^19.11.1
+$ TEST_BROWSER_DRIVER=puppeteer meteor test --once --driver-package <your package name>
+```
+
+### Playwright
+
+
+`playwright@^1.33.0` is the latest version with Node 14 compatibility (Meteor 2.x is set to use Node.js version 14.x by default).
+
+```bash
+$ npm i --save-dev playwright@^1.33.0
 $ TEST_BROWSER_DRIVER=puppeteer meteor test --once --driver-package <your package name>
 ```
 

--- a/README.md
+++ b/README.md
@@ -70,13 +70,14 @@ $ TEST_BROWSER_DRIVER=puppeteer meteor test --once --driver-package <your packag
 
 ### Playwright
 
-
 `playwright@^1.33.0` is the latest version with Node 14 compatibility (Meteor 2.x is set to use Node.js version 14.x by default).
 
 ```bash
 $ npm i --save-dev playwright@^1.33.0
-$ TEST_BROWSER_DRIVER=puppeteer meteor test --once --driver-package <your package name>
+$ TEST_BROWSER_DRIVER=playwright meteor test --once --driver-package <your package name>
 ```
+
+Use `PLAYWRIGHT_BROWSER` env to select the browser to use for testing. By default, it uses `chromium`.
 
 ### Selenium ChromeDriver
 

--- a/browser/chromedriver.js
+++ b/browser/chromedriver.js
@@ -58,6 +58,8 @@ export default function startChrome({
   // Can't hide the window but can move it off screen
   driver.manage().window().setRect(20000, 20000);
 
+  const LogsArgsRegex = /"([^"]*)"|(\b\d+\b)/g;
+
   // We periodically grab logs from Chrome and pass them back.
   // Every time we call this, we get only the log entries since
   // the previous time we called it.
@@ -70,7 +72,7 @@ export default function startChrome({
             stderr(`[ERROR] ${message}`);
           } else {
             function extractArgs(str) {
-              let rex = /"([^"]*)"|(\b\d+\b)/g;
+              let rex = LogsArgsRegex;
               let match;
               let args = [];
               while ((match = rex.exec(str)) !== null) {

--- a/browser/nightmare.js
+++ b/browser/nightmare.js
@@ -41,8 +41,8 @@ export default function startNightmare({
     // Controls maximum time client tests can take for Meteor to still
     // automatically exit after they complete.
     // Defaults to 20 days
-        waitTimeout: process.env.NIGHTMARE_WAIT_TIMEOUT || TWENTY_DAYS,
-      });
+    waitTimeout: process.env.NIGHTMARE_WAIT_TIMEOUT || TWENTY_DAYS,
+  });
 
   let testFailures;
   nightmare

--- a/browser/nightmare.js
+++ b/browser/nightmare.js
@@ -15,6 +15,8 @@ const TWENTY_DAYS = 1000 * 60 * 60 * 24 * 20;
 
 let nightmare;
 
+process.env.ELECTRON_DISABLE_SECURITY_WARNINGS = true;
+
 // Make sure the nightmare process does not stick around
 process.on('exit', () => {
   if (nightmare) {
@@ -39,8 +41,8 @@ export default function startNightmare({
     // Controls maximum time client tests can take for Meteor to still
     // automatically exit after they complete.
     // Defaults to 20 days
-    waitTimeout: process.env.NIGHTMARE_WAIT_TIMEOUT || TWENTY_DAYS,
-  });
+        waitTimeout: process.env.NIGHTMARE_WAIT_TIMEOUT || TWENTY_DAYS,
+      });
 
   let testFailures;
   nightmare
@@ -65,7 +67,10 @@ export default function startNightmare({
 
     // Meteor will call the `runTests` function exported by the driver package
     // on the client as soon as this page loads.
-    .goto(process.env.ROOT_URL)
+    .goto(process.env.ROOT_URL, {
+      'http-equiv': 'Content-Security-Policy',
+      content: 'script-src \'unsafe-eval\'',
+    })
 
     // After the page loads, the tests are running. Eventually they
     // finish and the driver package is supposed to set window.testsDone

--- a/browser/puppeteer.js
+++ b/browser/puppeteer.js
@@ -30,6 +30,7 @@ export default function startPuppeteer({
     // --no-sandbox and --disable-setuid-sandbox allow this to easily run in docker
     const browser = await puppeteer.launch({
       args: ['--no-sandbox', '--disable-setuid-sandbox'],
+      headless: 'new',
     });
     console.log(await browser.version());
     const page = await browser.newPage();


### PR DESCRIPTION
# Nightmare/Electron driver

Nightmare browser driver is working straight with latest version (`^3.0.2`). However, there, was an annoying warning around CSP, which I disabled it, since this is a test environment, not a production one, and we don't need to care about those securities issues.

![image](https://github.com/Meteor-Community-Packages/meteor-browser-tests/assets/2581993/2c643aa3-ac77-4e1f-80e8-4b351142a239)

![image](https://github.com/Meteor-Community-Packages/meteor-browser-tests/assets/2581993/1ac123ba-5343-43c9-bbec-0c3d9c36d011)
